### PR TITLE
Update Credit Role colour and position

### DIFF
--- a/src/modules/credits/index.ts
+++ b/src/modules/credits/index.ts
@@ -50,7 +50,9 @@ async function updateCredits() {
 			roles: m.roles.cache.filter(r => r.name !== "@everyone").map(r => r.name),
 			roleIds: m.roles.cache.filter(r => r.name !== "@everyone").map(r => r.id),
 			roleColor: staff ? colorRole.hexColor : highestRole.hexColor,
-			rolePosition: highestRole.position,
+			rolePosition: Object.values(creditRoles)
+				.reverse()
+				.findIndex(highestRole.id),
 			status: m.user.presence.status
 		};
 	});


### PR DESCRIPTION
Fixes by:
Fix role color by using `highestRole.hexcolor`, rather than highest available role color (Was broken by incorrect tenary)
Fix role position by using the position in local array, rather than discord positions