### PR TITLE
:bug: Shows all contributors

### DIFF
--- a/src/modules/credits/index.ts
+++ b/src/modules/credits/index.ts
@@ -19,7 +19,8 @@ async function updateCredits() {
 	let creditUsers = client.guilds.cache.first().members.cache;
 	creditUsers.sweep(m => {
 		const s = settings.find(s => s.userId === m.id);
-		if (typeof s !== "undefined" && !s.showContributor) return true;
+		if (typeof s?.showContributor !== "undefined" && !s.showContributor)
+			return true;
 
 		return !creditRolesValues.some(cR => m.roles.cache.has(cR));
 	});


### PR DESCRIPTION
Fixes undefined showContributor on settings

If a user had a setting record but not used showContributor, then an undefined will be present, the code checks the inverted boolean state which will return true. i.e suggests that the user has showContributor as false, and then removes them from the array.