### PR TITLE
fix: update channel id of presence-dev

### DIFF
--- a/src/modules/utility/commands/info.ts
+++ b/src/modules/utility/commands/info.ts
@@ -131,7 +131,7 @@ export const shortInfos: {
 	docs: {
 		title: "Read the Docs",
 		description:
-			"If you have any questions regarding PreMiD, please read our documentation before creating a ticket. Presence development related queries should be redirected to <#1019727742335463474>",
+			"If you have any questions regarding PreMiD, please read our documentation before creating a ticket. Presence development related queries should be redirected to <#607524579874832446>",
 		links: [
 			{
 				label: "Documentation",


### PR DESCRIPTION
Simply changed the Channel ID of the Info command from a unknown channel to #presence-dev

![image](https://github.com/PreMiD/Discord-Bot/assets/65812282/4e06e8b2-7d6c-4eae-9784-79b1bbf56be1)
